### PR TITLE
Fix anchor link handling in translations

### DIFF
--- a/build.js
+++ b/build.js
@@ -522,7 +522,9 @@ const Builder = function(outBaseDir, options) {
   }
 
   function isArticleLink(url) {
-    return !url.includes('/') && url.endsWith('.html');
+    // Handle both regular html links and html links with anchors in them
+    const baseUrl = url.split('#')[0];
+    return !baseUrl.includes('/') && baseUrl.endsWith('.html');
   }
 
   // Try top fix relative links. This *should* only


### PR DESCRIPTION
Fixes an issue where anchor links (e.g., webgpu-fundamentals.html#section) in translation pages were incorrectly redirecting to the English version instead of staying within the same language directory.
You can hit the problem from JA/KO translations of [webgpu-storage-textures](https://webgpufundamentals.org/webgpu/lessons/webgpu-storage-textures.html).
They have a link to English page (https://webgpufundamentals.org/webgpu/lessons/webgpu-fundamentals.html#a-run-computations-on-the-gpu ) not their translated page.

The problem was in the isArticleLink() function which didn't properly recognize HTML files with anchors as article links. Now it splits the URL on '#' and checks the base URL.

Before: webgpu-fundamentals.html#anchor -> ../webgpu-fundamentals.html#anchor (English)
After:  webgpu-fundamentals.html#anchor -> webgpu-fundamentals.html#anchor (Same language)

🤖 Generated with [Claude Code](https://claude.ai/code)